### PR TITLE
chore: bump org.jruby:jruby from 9.4.3.0 to 9.4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
       <dependency>
         <groupId>org.jruby</groupId>
         <artifactId>jruby</artifactId>
-        <version>9.4.3.0</version>
+        <version>9.4.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bumps org.jruby:jruby from 9.4.3.0 to 9.4.6.0.

---
updated-dependencies:
- dependency-name: org.jruby:jruby dependency-type: direct:production update-type: version-update:semver-patch ...

Thank you for submitting a pull request to the WebGoat!
